### PR TITLE
Fix for 'cv.h/highgui.h no-such-file-or-directory' header issue

### DIFF
--- a/autosegmenter/src/IPPInterface/IPPImage.h
+++ b/autosegmenter/src/IPPInterface/IPPImage.h
@@ -56,8 +56,8 @@
 #include "ipp.h"
 #include "ippcv.h"
 
-#include "cv.h"
-#include "highgui.h"
+#include <opencv/cv.h>
+#include <opencv/highgui.h>
 
 #include "diamond/rgb.h"
 


### PR DESCRIPTION
Added a fix for a problem where compiling IPPImage.h halted do to a header import issue.
